### PR TITLE
Python 2.7 requires an older syntax when calling super()

### DIFF
--- a/familysearch/__init__.py
+++ b/familysearch/__init__.py
@@ -120,7 +120,7 @@ class FamilySearch(Authentication, Authorities, ChangeHistory, Discovery,
         self.logged_in = bool(self.access_token)
 
         Discovery.__init__(self)
-        super().__init__()
+        super(FamilySearch, self).__init__()
         # Discovery needs to explicitly be first, as it is the hypermedia
         # engine.
 


### PR DESCRIPTION
Fixes `TypeError: super() takes at least 1 argument (0 given)` with Python 2.7. Also tested with 3.4.
